### PR TITLE
Fix GitHub Actions for updating dataset repos

### DIFF
--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -45,7 +45,7 @@ jobs:
           MERGE_LABELS: automerge
           MERGE_METHOD: merge
           MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
-          MERGE_REQUIRED_APPROVALS: 0
+          MERGE_REQUIRED_APPROVALS: 1
           MERGE_DELETE_BRANCH: "false"
           MERGE_ERROR_FAIL: "true"
           PULL_REQUEST: ${{ matrix.fork }}/${{ steps.create-pull-request.outputs.pull-request-number }}

--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
 jobs:
   update-dataset-repo:
+    if: github.repository == 'neurodatascience/mr_proc'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository == 'neurodatascience/mr_proc'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         fork:
           - neurodatascience/mr_proc-ppmi

--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -39,6 +39,7 @@ jobs:
           review-message: PR approved by [auto-approve-action](https://github.com/michellewang/auto-approve-action) GitHub action.
           github-token: ${{ secrets.GH_ACTION_PAT }}
       - name: Automerge Pull Request
+        id: automerge-pull-request
         if: ${{ steps.create-pull-request.outputs.pull-request-number }}
         uses: pascalgn/automerge-action@v0.15.6
         env:
@@ -50,3 +51,9 @@ jobs:
           MERGE_DELETE_BRANCH: "false"
           MERGE_ERROR_FAIL: "true"
           PULL_REQUEST: ${{ matrix.fork }}/${{ steps.create-pull-request.outputs.pull-request-number }}
+      - name: Fail job if Pull Request wasn't ready to be merged
+        if: steps.automerge-pull-request.outputs.mergeResult == 'not_ready'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed("Pull request #${{ steps.automerge-pull-request.outputs.pullRequestNumber }} is not ready to be merged. This is probably due to merge conflicts: fix them in neurodatascience/mr_proc or in each of neurodatascience/mr_proc-[dataset] before trying again.")

--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -29,14 +29,14 @@ jobs:
           token: ${{ secrets.PAT }}
           branch: main-upstream
           labels: automerge
-#       - name: Approve Pull Request
-#         if: ${{ steps.create-pull-request.outputs.pull-request-number }}
-#         uses: michellewang/auto-approve-action@v3
-#         with:
-#           repository: ${{ matrix.fork }}
-#           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
-#           review-message: PR approved by [auto-approve-action](https://github.com/michellewang/auto-approve-action) GitHub action.
-#           github-token: ${{ secrets.PAT2 }}
+      - name: Approve Pull Request
+        if: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        uses: michellewang/auto-approve-action@v3
+        with:
+          repository: ${{ matrix.fork }}
+          pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+          review-message: PR approved by [auto-approve-action](https://github.com/michellewang/auto-approve-action) GitHub action.
+          github-token: ${{ secrets.PAT2 }}
       - name: Automerge Pull Request
         if: ${{ steps.create-pull-request.outputs.pull-request-number }}
         uses: pascalgn/automerge-action@v0.15.6

--- a/.github/workflows/update_dataset_repos.yml
+++ b/.github/workflows/update_dataset_repos.yml
@@ -37,7 +37,7 @@ jobs:
           repository: ${{ matrix.fork }}
           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
           review-message: PR approved by [auto-approve-action](https://github.com/michellewang/auto-approve-action) GitHub action.
-          github-token: ${{ secrets.PAT2 }}
+          github-token: ${{ secrets.GH_ACTION_PAT }}
       - name: Automerge Pull Request
         if: ${{ steps.create-pull-request.outputs.pull-request-number }}
         uses: pascalgn/automerge-action@v0.15.6


### PR DESCRIPTION
Fix bug in PR #70 where the newly created PRs aren't merged because they haven't been approved, even if the PAT is from an admin (see [here](https://github.com/pascalgn/automerge-action/issues/200)). Now the GitHub Actions workflow uses a second Personal Access Token to approve the PR. Then, like before, it will try to merge the PR. If the PR can't be merged (for example due to merge conflicts), the run will fail. 

Notes:
* I have re-enabled the "Do not allow bypassing the above settings" branch protection rule again since it seems we can't bypass approval requirements through the GitHub API anyway.
* Sometimes the PR can't be merged even though there are no conflicts. This is because GitHub doesn't always accurately compute if a PR can be merged (see [here](https://github.com/pascalgn/automerge-action#configuration)). In that case the workflow can be manually re-run through GitHub.

Other changes:
* Only run workflow in `neurodatascience/mr_proc`, not in any other fork
* Don't automatically cancel other running jobs if one of them failed