### PR TITLE
added pybids as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ install_requires =
     joblib
     pydicom
     nibabel
+    pybids


### PR DESCRIPTION
pybids is called but wasn't part of the installation.

I'm using it to parse inputs to try and automate decisions about how / what files are used.

This shouldn't conflict / is a worthwhile dependency.