### PR TITLE
Update sample global configs

### DIFF
--- a/sample_global_configs.json
+++ b/sample_global_configs.json
@@ -10,6 +10,7 @@
     "TEMPLATEFLOW_DIR": "",
 
     "SESSIONS": ["1","2"],
+    "VISITS": ["V01", "V02"],
 
     "BIDS": {
         "heudiconv": {
@@ -39,6 +40,33 @@
             "VERSION": "6.0.1",
             "CONTAINER": "fmriprep_{}.sif",
             "URL": ""
+        }
+    },
+
+    "TABULAR": {
+        "DEMOGRAPHICS": {
+            "SEX": {
+                "VERSION": "",
+                "FILENAME": ""
+            },
+            "DATE_OF_BIRTH": {
+                "VERSION": "",
+                "FILENAME": ""
+            }
+        },
+        "ASSESSMENTS": {
+            "UPDRS_3": {
+                "VERSION": "",
+                "FILENAME": ""
+            },
+            "MOCA": {
+                "VERSION": "",
+                "FILENAME": ""
+            },
+            "GROUP": {
+                "VERSION": "",
+                "FILENAME": ""
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `"VISITS"` key
- Add `"TABULAR"` key with subsections `"DEMOGRAPHICS"` and `"ASSESSMENTS"` (matches tree structure)
  - Should be used to generate phenotypic data bagels (and maybe the manifest)

Closes #100.